### PR TITLE
fix(client): DSH Desktop 增强模式下面板半透明难读 + 遮挡侧边栏入口按钮

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -30,14 +30,42 @@ window.__ModuleLoader__.load({
     var DEFAULT_W = 440
     var DEFAULT_H = 560
     var DEFAULT_GAP = 16
+    // 侧边栏「记忆」入口按钮位置(DSH Desktop 增强模式下面板贴左下角会盖住它)
+    function entryButtonRect() {
+      try {
+        var btn = document.querySelector('[data-dam-sidebar-btn]')
+        if (btn) { var r = btn.getBoundingClientRect(); if (r && r.width > 0) return r }
+      } catch (e) {}
+      return null
+    }
     function defaultGeom() {
       var vh = window.innerHeight || 800
+      var top = Math.max(DEFAULT_GAP, vh - DEFAULT_H - DEFAULT_GAP)
+      // 默认锚定在「记忆」按钮正上方,保证开关入口始终可见可点
+      var r = entryButtonRect()
+      if (r) {
+        var anchored = r.top - DEFAULT_H - 12
+        if (anchored >= DEFAULT_GAP) top = Math.min(top, anchored)
+      }
       return {
         left: DEFAULT_GAP,
-        top: Math.max(DEFAULT_GAP, vh - DEFAULT_H - DEFAULT_GAP),
+        top: top,
         width: DEFAULT_W,
         height: DEFAULT_H,
       }
+    }
+    // 面板与「记忆」入口按钮重叠时自动上移让出入口(含旧版本持久化的贴底几何)
+    function avoidCoveringEntry() {
+      var r = entryButtonRect()
+      if (!r) return
+      var g = controller.geom()
+      var overlapX = g.left < r.right + 4 && g.left + g.width > r.left - 4
+      var overlapY = g.top < r.bottom + 4 && g.top + g.height > r.top - 4
+      if (!overlapX || !overlapY) return
+      var top = r.top - g.height - 12
+      if (top < DEFAULT_GAP) top = DEFAULT_GAP
+      geom = clampGeom({ left: g.left, top: top, width: g.width, height: g.height })
+      persistGeom()
     }
     var geom = null
     function clampGeom(g) {
@@ -60,6 +88,16 @@ window.__ModuleLoader__.load({
       return clampGeom(defaultGeom())
     }
     function persistGeom() { if (geom) { try { localStorage.setItem(GEOM_KEY, JSON.stringify(geom)) } catch (e) {} } }
+    // 解析 computed color(rgba() / color(srgb))的通道与 alpha,用于可读性兜底
+    function parseCssColor(str) {
+      if (!str) return null
+      function alphaOf(v) { return v === undefined ? 1 : (v.charAt(v.length - 1) === '%' ? parseFloat(v) / 100 : parseFloat(v)) }
+      var m = /^rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)(?:[,\s/]+([\d.]+%?))?\s*\)$/i.exec(str)
+      if (m) return { r: Math.round(+m[1]), g: Math.round(+m[2]), b: Math.round(+m[3]), a: alphaOf(m[4]) }
+      var c = /^color\(\s*srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)(?:\s*\/\s*([\d.]+%?))?\s*\)$/i.exec(str)
+      if (c) return { r: Math.round(+c[1] * 255), g: Math.round(+c[2] * 255), b: Math.round(+c[3] * 255), a: alphaOf(c[4]) }
+      return null
+    }
     function emit() { listeners.forEach(function (fn) { try { fn() } catch (e) {} }) }
     var controller = {
       isOpen: function () { return panelOpen },
@@ -80,6 +118,7 @@ window.__ModuleLoader__.load({
       toggle: function () { if (panelOpen) controller.close(); else controller.open() },
       open: function () {
         if (closeTimer) { clearTimeout(closeTimer); closeTimer = null }
+        avoidCoveringEntry()
         panelOpen = true; panelClosing = false; emit()
       },
       close: function () {
@@ -596,6 +635,7 @@ window.__ModuleLoader__.load({
       '[data-dam-panel][data-scale="xl"] { --dam-scale: 1.3; }',
       '[data-dam-panel]::before { content: ""; position: absolute; inset: 0 0 auto 0; height: 64%; pointer-events: none;',
       '  background: linear-gradient(180deg, rgba(255,255,255,.13), rgba(255,255,255,0) 70%); border-radius: 16px 16px 0 0; }',
+      '[data-dam-panel][data-solid="true"]::before { background: linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,0) 70%); }',
       '[data-dam-panel][data-dragging="true"] { user-select: none; }',
       '[data-dam-panel] header { display: flex; align-items: center; gap: 8px; padding: 10px 14px; cursor: grab;',
       '  border-bottom: 1px solid color-mix(in srgb, var(--dsw-alias-border-l1, rgba(128,128,128,.25)) 55%, transparent); }',
@@ -1659,6 +1699,7 @@ window.__ModuleLoader__.load({
 
     function MemoryPanel() {
       var tick = useTick()
+      var panelRef = useRef(null)
       var tabPair = useState('overview')
       var tab = tabPair[0]
       var setTab = tabPair[1]
@@ -1668,6 +1709,23 @@ window.__ModuleLoader__.load({
       var setNonce = noncePair[1]
       var g = controller.geom()
       useEffect(function () { return controller.subscribe(tick[1]) }, [])
+      // 可读性兜底:DSH Desktop 增强模式 + 透明/Mica 窗口材质下,主题令牌(--dsw-alias-bg-overlay)本身半透明,
+      // 再经 58% 混合后文字几乎不可读;实测面板背景 alpha 过低时强制提升到 0.96(保留色相,仅提不透明度)
+      useEffect(function () {
+        if (!panelOpen) return
+        var el = panelRef.current
+        if (!el) return
+        try {
+          var col = parseCssColor(getComputedStyle(el).backgroundColor)
+          if (col && col.a < 0.9) {
+            el.style.background = 'rgba(' + col.r + ', ' + col.g + ', ' + col.b + ', 0.96)'
+            el.setAttribute('data-solid', 'true')
+          } else {
+            el.style.background = ''
+            el.removeAttribute('data-solid')
+          }
+        } catch (e) {}
+      }, [panelOpen])
       if (!panelOpen && !panelClosing) return null
       var body
       if (tab === 'overview') body = h(OverviewTab, { nonce: nonce })
@@ -1696,6 +1754,7 @@ window.__ModuleLoader__.load({
       return h('div', {
         'data-dam-panel': '',
         'data-scale': fontScale in FONT_SCALES ? fontScale : 'md',
+        ref: panelRef,
         style: style,
         'data-closing': panelClosing ? 'true' : undefined,
         'data-dragging': dragActive ? 'true' : undefined,
@@ -2104,6 +2163,29 @@ window.__ModuleLoader__.load({
           if (closeTimer) { clearTimeout(closeTimer); closeTimer = null }
         }
       }, 'dsh-auto-memory: styles')
+
+      // 面板外交互关闭:点击面板外任意处 / 按 Esc 关闭。
+      // 增强模式下面板可能盖住侧边栏入口按钮,这里提供不依赖按钮的兜底关闭手段;
+      // 点击入口按钮本身排除在外(保留按钮 toggle 语义)。
+      try {
+        var onDocPointerDown = function (e) {
+          if (!panelOpen || panelClosing) return
+          var el = e.target
+          if (el && el.closest && (el.closest('[data-dam-panel]') || el.closest('[data-dam-sidebar-btn]'))) return
+          controller.close()
+        }
+        var onDocKeyDown = function (e) {
+          if (e.key === 'Escape' && panelOpen && !panelClosing) controller.close()
+        }
+        document.addEventListener('pointerdown', onDocPointerDown, true)
+        document.addEventListener('keydown', onDocKeyDown, true)
+        ctx.effect(function () {
+          return function () {
+            document.removeEventListener('pointerdown', onDocPointerDown, true)
+            document.removeEventListener('keydown', onDocKeyDown, true)
+          }
+        }, 'dsh-auto-memory: panel-outside-close')
+      } catch (e) {}
 
       var slots = ctx.slots
       if (!slots) { console.warn('[dsh-auto-memory] slots service unavailable'); return }


### PR DESCRIPTION
## 问题 | Problem

在 DSH Desktop **增强模式（advanced mode）**、尤其是开启透明 / Mica 窗口材质时，记忆面板有两个体验问题：

1. **面板半透明、文字几乎不可读**：面板背景是 `color-mix(in srgb, var(--dsw-alias-bg-overlay) 58%, transparent)` + `backdrop-filter`。增强模式下 `--dsw-alias-bg-overlay` 主题令牌本身就是半透明的（需要透出桌面背景），再按 58% 混合后实际不透明度仅约 50%，背后内容直接干扰阅读。
2. **面板遮挡左下角「记忆」入口按钮**：默认位置 `top = vh - 560 - 16` 紧贴屏幕底部，正好盖住侧边栏 footer 里的入口按钮，无法通过再次点击按钮关闭面板。

修复前 Before
<img width="964" height="1630" alt="QQ20260831-100228" src="https://github.com/user-attachments/assets/9e2407d8-915a-4424-a885-6360e3fbb5a1" />

修复后 After
<img width="924" height="1676" alt="QQ20260831-102415" src="https://github.com/user-attachments/assets/bc82245d-df91-4029-9c44-94e62a9c8061" />

## 改动 | Changes

仅修改 `lib/client.js`（+83 / -1），未动版本号与 CHANGELOG：

**1. 可读性自适应兜底（不破坏普通模式的毛玻璃观感）**
- 面板每次打开时用 `getComputedStyle` 实测背景色的 alpha，低于 0.9 时才把同色相背景强制提升到 `rgba(r, g, b, 0.96)` 内联样式，并弱化 `::before` 顶部高光（13% → 5%）
- 新增 `parseCssColor()`，同时兼容浏览器的 `rgba()` 与 `color(srgb …)` 两种 computed value 序列化
- 普通网页模式 alpha 正常 → 完全不触发，原有液态玻璃视觉零变化

**2. 入口按钮防遮挡**
- `defaultGeom()` 改为锚定在「记忆」按钮正上方（实时读取按钮 `getBoundingClientRect`），重置位置（⤾）同样受益
- `open()` 时检测面板与按钮重叠则自动上移让出——兼容旧版本 localStorage 里持久化的贴底几何，老用户升级后首次打开即自动归位
- 刻意只在打开时避让，拖拽过程中不实时推开，避免与用户抢鼠标

**3. 面板外交互关闭（兜底）**
- 点击面板外任意处、或按 `Esc` 关闭面板（document 捕获阶段监听，入口按钮与面板内部豁免，保留按钮 toggle 语义）
- 监听器通过 `ctx.effect` 注册，随插件卸载自动清理

## 兼容性 | Compatibility

- 不改版本号、CHANGELOG、UI 版本标签，发版节奏由作者决定
- 不涉及 host 端（`lib/index.js`）、API 与持久化格式，纯客户端表现层修复
- 普通（非增强）模式行为完全不变：透明度正常时兜底不触发，默认位置仅从「贴屏幕底」变为「按钮正上方」

## 测试 | Testing

- `node --check lib/client.js` 通过
- `parseCssColor` 6 组用例（`rgba` 带/不带 alpha、`rgb`、`color(srgb)` 带/不带 alpha、百分比 alpha、无法解析输入）验证通过
- 已在 DSH Desktop 增强模式实测：替换安装副本后面板不透明可读、不再遮挡入口按钮、外点 / Esc 可关闭
- 冒烟测试 `smoke-test.mjs` 为 host 端测试且本环境无 node_modules 未运行；本次改动不涉及 host 端
