### PR TITLE
fix: session 事件读取兼容新版 DSH Session API（snapshotEvents 兜底），修复自动沉淀 100% 失效

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1228,7 +1228,7 @@ class MemoryEngine {
       if (!agent || typeof agent !== 'object') return 0
       const runtime = this.resolveObserverRuntime(agent)
       if (!runtime || runtime.disposed) return 0
-      const events = agent.session && Array.isArray(agent.session.events) ? agent.session.events : []
+      const events = sessionEventsOf(agent && agent.session)
       const capped = events.length > SEED_REPLAY_MAX_EVENTS ? events.slice(-SEED_REPLAY_MAX_EVENTS) : events
       this._observerStats.seedTruncatedEvents += events.length - capped.length
       let seeded = 0
@@ -1578,7 +1578,7 @@ class MemoryEngine {
       // compaction 事件感知:harness 刚发生 compaction/summary|prune → 无论水位,立即补写交接材料
       let compacted = false
       try {
-        const events = (agent.session && agent.session.events) || []
+        const events = sessionEventsOf(agent && agent.session)
         for (let i = Math.max(0, events.length - 64); i < events.length; i++) {
           const t = events[i] && events[i].type
           if (t === 'compaction/summary' || t === 'compaction/prune') {
@@ -3208,7 +3208,7 @@ class MemoryEngine {
       const a = agentSvc.get(best.id)
       if (a && a.session && a.session.header && a.session.header.parentSession === undefined) {
         this._lastAgent = a
-        diag('restoreLastAgent: recovered agent id=' + a.id + ' session=' + a.session.id + ' logEvents=' + ((a.session.events && a.session.events.length) || 0))
+        diag('restoreLastAgent: recovered agent id=' + a.id + ' session=' + a.session.id + ' logEvents=' + sessionEventsOf(a.session).length)
       } else {
         diag('restoreLastAgent: candidate rejected (id=' + (a && a.id) + ' hasSession=' + !!(a && a.session) + ' parent=' + (a && a.session && a.session.header && a.session.header.parentSession) + ')')
       }
@@ -3413,7 +3413,7 @@ class MemoryEngine {
     runtime.lastTurn = turn
     // 取本轮最后一条 user + 最后一条 assistant(模型可见消息序列)
     const messages = extractSessionMessages(agent)
-    if (messages.length < 2) { why('messages<2 got=' + messages.length + ' seqs=' + ((agent.session.surface && agent.session.surface.nodes && (Array.isArray(agent.session.surface.nodes) ? agent.session.surface.nodes.length : 'set')) || 'none') + ' events=' + ((agent.session.events && agent.session.events.length) || 'none')); return }
+    if (messages.length < 2) { why('messages<2 got=' + messages.length + ' seqs=' + ((agent.session.surface && agent.session.surface.nodes && (Array.isArray(agent.session.surface.nodes) ? agent.session.surface.nodes.length : 'set')) || 'none') + ' events=' + (sessionEventsOf(agent && agent.session).length || 'none')); return }
     // 2026-08-30 intent 提纯(三层):①只认真人消息事件 'user/message'(tool/result 在协议里
     // 也是 user 角色,正文常是 JSON/行号文本)②跳过 harness 合成的上下文注入消息
     // ("Current runtime context." 开头 / 含 <memory_system>)③剥离注入快照块,取其后真人问题。
@@ -4442,13 +4442,33 @@ function textOfContent(content) {
   walk(content, 0)
   return out.join('')
 }
+/**
+ * 新旧两代 Session API 兼容的原始事件数组读取:
+ * - 旧版 @deepseek-ai/dsh-session 在 Session 上暴露 .events 数组;
+ * - 新版已移除 .events,事件读取走 snapshotEvents()(内部 eventsSnapshot 缓存,
+ *   同一 log 追加前重复调用零重复开销;返回 frozen 数组,只读安全)。
+ * 返回值恒为数组(找不到任何来源时为 []),不做截断——调用方各自决定窗口。
+ */
+function sessionEventsOf(session) {
+  try {
+    if (!session) return []
+    if (Array.isArray(session.events)) return session.events
+    if (typeof session.snapshotEvents === 'function') {
+      const snap = session.snapshotEvents()
+      if (Array.isArray(snap)) return snap
+    }
+  } catch (e) {}
+  return []
+}
 function extractSessionMessages(agent) {
   try {
     const session = agent && agent.session
     if (!session) return []
-    // 只读 events 数组(截断尾部),绝不访问 session.surface.nodes:
+    // 只读事件数组(截断尾部),绝不访问 session.surface.nodes:
     // 该访问会触发惰性投影,长会话(上万事件)时同步遍历阻塞主线程 → 窗口卡死/超时。
-    const eventsRaw = session.events || []
+    // 2026-09 兼容:新版 harness Session 已移除 .events 属性(原注释针对旧版 API),
+    // 统一经 sessionEventsOf() 读取(新版走 snapshotEvents(),自带缓存,同样零投影访问)。
+    const eventsRaw = sessionEventsOf(session)
     const events = eventsRaw.length > 2000 ? eventsRaw.slice(-2000) : eventsRaw
     const out = []
     for (let i = 0; i < events.length; i++) {


### PR DESCRIPTION
Closes #16

## 问题

当前 DSH 的 `@deepseek-ai/dsh-session` Session 类已**移除 `.events` 属性**（事件读取 API 为 `snapshotEvents()`/`ownEvents()`，内部带 `eventsSnapshot` 缓存）。插件 5 处直接读取 `agent.session.events` 的代码全部拿到 `undefined`，导致：

- **自动沉淀 100% 失效**：`consolidateTurn → extractSessionMessages` 恒得空数组，每轮 `consolidate skip: messages<2 got=0 ... events=none`（实测 35 次尝试 0 次成功）
- `seedRuntimeFromSession`（M2.4 会话事件补放）恒为空
- 水位感知的 compaction 事件探测恒为空

而 M2.1 实时观察路（`ctx.on('session/event')`）不受影响——所以表现为"观察正常、沉淀为零"。

## 修复

新增模块级兼容读取助手 `sessionEventsOf(session)`：

1. 优先读旧版 `.events`（兼容旧 host / 混合环境，行为零变化）
2. 否则走 `session.snapshotEvents()`（frozen 数组、自带缓存；**不触碰 surface 投影**，原"绝不访问 surface.nodes"的性能护栏继续成立）
3. 都不可得时返回 `[]`，恒不返回 undefined

替换全部 5 处读取点（`extractSessionMessages`、`seedRuntimeFromSession`、水位 compaction 探测、`restoreLastAgent` 与 consolidate 的两处 diag 计数），原有截断窗口逻辑（-2000 / SEED_REPLAY_MAX_EVENTS / 末 64 事件）保持不变，只是数据源换成兼容读取。

## 验证

- `node --check` 通过；改动为机械替换（4 处以唯一字符串断言替换）
- 旧版 host（.events 存在）走第一分支，行为与现状完全一致；新版 host 走 snapshotEvents()，consolidate/seed 恢复读数
- 已在实际环境（DSH Desktop Windows，2.1.2 安装包 + 本补丁同源代码）确认 `seqs=N`（surface 投影）一直有数据，仅 `.events` 缺失