### PR TITLE
fix: extractSessionMessages 先过滤消息类事件再做 2000 条截尾，修复重型回合自动沉淀失效（empty text user=0）

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4737,8 +4737,19 @@ function extractSessionMessages(agent) {
     // 该访问会触发惰性投影,长会话(上万事件)时同步遍历阻塞主线程 → 窗口卡死/超时。
     // 2026-09 兼容:新版 harness Session 已移除 .events 属性(原注释针对旧版 API),
     // 统一经 sessionEventsOf() 读取(新版走 snapshotEvents(),自带缓存,同样零投影访问)。
-    const eventsRaw = sessionEventsOf(session)
-    const events = eventsRaw.length > 2000 ? eventsRaw.slice(-2000) : eventsRaw
+    // 2026-09-08 修复:先过滤出承载消息的事件,再做 2000 条截尾。
+    // 原实现直接对全量事件日志截尾——新版 harness 内存日志含海量流式 chunk 事件
+    // (reasoning-chunks/text-chunks/tool-call-chunks/assistant-chunks,实测重型回合
+    // ~24 条/秒、单回合数千条),真人 user/message 会被挤出 2000 条窗口,导致
+    // consolidateTurn 恒报 "empty text user=0"。messageOfEvent 对 chunk 类事件恒
+    // 返回 null,先过滤零损失;截尾窗口仍保留,兜底防超长会话。
+    const allEvents = sessionEventsOf(session)
+    const msgEvents = []
+    for (let i = 0; i < allEvents.length; i++) {
+      const ev = allEvents[i]
+      if (ev && (ev.type === 'user/message' || ev.type === 'assistant/message' || ev.type === 'tool/result')) msgEvents.push(ev)
+    }
+    const events = msgEvents.length > 2000 ? msgEvents.slice(-2000) : msgEvents
     const out = []
     for (let i = 0; i < events.length; i++) {
       const ev = events[i]

--- a/tests/smoke/smoke-test-extract-chunk-flood.mjs
+++ b/tests/smoke/smoke-test-extract-chunk-flood.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/** [chunk-flood] extractSessionMessages 截尾窗口回归(2026-09-08)。
+ * 真实抽取 extractSessionMessages(花括号配平),注入 sessionEventsOf/messageOfEvent/textOfContent
+ * 后在受控闭包里驱动 —— 测的是随包发布的真实代码:
+ *   G1 chunk 洪流:真人 user/message 后跟 >2000 条流式 chunk → 窗口仍能取到该消息(修复点)
+ *   G2 窗口兜底:消息类事件超过 2000 条 → 提取数 ≤2000,且含最新一条
+ *   G3 旧版 host:session 以 .events 数组暴露时行为一致
+ *   G4 源码守卫:过滤先于截尾(防止未来重构悄悄退化回"全量截尾")
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const SRC = readFileSync(path.resolve(HERE, '..', '..', 'lib', 'index.js'), 'utf8')
+let pass = 0, fail = 0
+const ok = (c, n) => { if (c) { pass++; console.log('  ok -', n) } else { fail++; console.log('  FAIL -', n) } }
+
+// —— 源码抽取器(花括号配平,同 smoke-test-handoff-pre) ——
+function extractFn(header) {
+  const start = SRC.indexOf(header)
+  if (start < 0) throw new Error('not found: ' + header)
+  let depth = 0, end = -1
+  for (let i = start + header.length - 1; i < SRC.length; i++) {
+    if (SRC[i] === '{') depth++
+    else if (SRC[i] === '}') { depth--; if (depth === 0) { end = i; break } }
+  }
+  if (end < 0) throw new Error('unbalanced: ' + header)
+  return SRC.slice(start, end + 1)
+}
+const extractSessionMessages = new Function(
+  'sessionEventsOf', 'messageOfEvent', 'textOfContent',
+  'return (' + extractFn('function extractSessionMessages(agent) {') + ')'
+)(sessionEventsOf, messageOfEvent, textOfContent)
+function sessionEventsOf(session) {
+  try {
+    if (!session) return []
+    if (Array.isArray(session.events)) return session.events
+    if (typeof session.snapshotEvents === 'function') return session.snapshotEvents()
+  } catch (e) {}
+  return []
+}
+function messageOfEvent(ev) {
+  if (!ev) return null
+  if (ev.type === 'user/message') return ev.data && ev.data.message ? ev.data.message : ev.data
+  if (ev.type === 'assistant/message' || ev.type === 'tool/result') return ev.data && ev.data.message
+  return null
+}
+function textOfContent(content) {
+  const out = []
+  const walk = (v, depth) => {
+    if (depth > 8 || v == null) return
+    if (typeof v === 'string') { out.push(v); return }
+    if (Array.isArray(v)) { for (const x of v) walk(x, depth + 1); return; }
+    if (typeof v !== 'object') return
+    if (typeof v.text === 'string') out.push(v.text)
+    else if (typeof v.input_text === 'string') out.push(v.input_text)
+    if (v.content !== undefined) walk(v.content, depth + 1)
+  }
+  walk(content, 0)
+  return out.join('')
+}
+
+console.log('[chunk-flood] G1 真人消息被 >2000 条流式 chunk 淹没后仍可取到')
+const QUESTION = '请帮我复核一下这两个方案是否可行，并给出具体依据'
+const flood = [ { type: 'user/message', data: { role: 'user', content: [{ type: 'text', text: QUESTION }] } } ]
+for (let i = 0; i < 4680; i++) flood.push({ type: 'reasoning-chunks', data: { delta: 'thinking...' } })
+flood.push({ type: 'assistant/message', data: { message: { role: 'assistant', content: [{ type: 'text', text: '已复核，结论如下。' }] } } })
+const m1 = extractSessionMessages({ session: { snapshotEvents: () => flood } })
+const picked = m1.filter(m => m.role === 'user' && m.eventType === 'user/message')
+ok(picked.length >= 1 && picked[picked.length - 1].text.includes('复核') && picked[picked.length - 1].text === QUESTION,
+  'chunk 洪流后真人提问仍在提取结果中(' + (picked[picked.length - 1] || {}).text?.slice(0, 20) + '…)')
+
+console.log('[chunk-flood] G2 消息类事件超过 2000 条 → 窗口兜底仍生效')
+const big = [ { type: 'user/message', data: { role: 'user', content: [{ type: 'text', text: '最初的问题' }] } } ]
+for (let i = 0; i < 2500; i++) big.push({ type: 'tool/result', data: { message: { role: 'user', content: [{ type: 'text', text: 'tool output ' + i }] } } })
+big.push({ type: 'assistant/message', data: { message: { role: 'assistant', content: [{ type: 'text', text: '回答' }] } } })
+const m2 = extractSessionMessages({ session: { snapshotEvents: () => big } })
+ok(m2.length <= 2000, '提取消息数 ≤ 2000(实际 ' + m2.length + ')')
+ok(m2.length > 0 && m2[m2.length - 1].text === '回答', '窗口保留最新一条消息')
+
+console.log('[chunk-flood] G3 旧版 host(.events 数组)行为一致')
+const legacy = { events: [
+  { type: 'user/message', data: { role: 'user', content: [{ type: 'text', text: '帮我看看这个配置' }] } },
+  { type: 'assistant/message', data: { message: { role: 'assistant', content: [{ type: 'text', text: '配置检查完了' }] } } },
+] }
+const m3 = extractSessionMessages({ session: legacy })
+ok(m3.length === 2 && m3[0].text === '帮我看看这个配置' && m3[1].text === '配置检查完了', '旧版 host 提取一致')
+
+console.log('[chunk-flood] G4 源码守卫:过滤先于截尾')
+const fnSrc = extractFn('function extractSessionMessages(agent) {')
+const filterIdx = fnSrc.indexOf("ev.type === 'user/message'")
+const capIdx = fnSrc.indexOf('slice(-2000)')
+ok(filterIdx !== -1 && capIdx !== -1 && filterIdx < capIdx, '过滤逻辑位于截尾之前(防退化)')
+
+console.log('[chunk-flood] 结果: pass=' + pass + ' fail=' + fail)
+process.exit(fail ? 1 : 0)


### PR DESCRIPTION
Closes #22

## 根因（详见 #22）

`extractSessionMessages()` 的 2000 条截尾窗口作用在**内存全量事件日志**上。新版 harness 的内存日志含海量流式 chunk 事件（`reasoning-chunks`/`text-chunks`/`tool-call-chunks`/`assistant-chunks`），重型回合实测 ≈24 条/秒（两条真人消息之间 7 分钟消耗 9859 个 seq）。用户消息发出后 1~2 分钟即被挤出窗口，turn-stopping 触发沉淀时提纯器取不到真人文本 → `empty text user=0` → 恒跳过。

"assistant/message 取得到（单条事件贴近日志尾部）、user/message 取不到（被 chunk 挤飞）"是该 bug 的指纹。

## 方案取舍

评估了四种修法：

| 方案 | 思路 | 结论 |
|---|---|---|
| **A. 先过滤消息类事件再截尾（本 PR）** | 截尾前只保留 `messageOfEvent` 能产出结果的全部三类事件（`user/message`/`assistant/message`/`tool/result`） | ✅ 最小侵入；窗口语义修正为"最后 2000 条**对话相关**事件"（与函数职责一致）；三条性能护栏全部保留；新旧 host 通用 |
| B. 复用 M2.1 已收到的 session/event 流按 turn 聚合 | 彻底摆脱对 session 对象形状的依赖 | ❌ 需要为每 runtime 增加事件缓冲/去重/回放语义，改动面大、回归风险高，超出本 bug 的最小修复范围；可作为后续演进方向 |
| C. 改用 `session.deriveMessages()` / surface 投影 | 取模型可见消息序列 | ❌ 正是本函数注释里明令避免的路径：surface 触发惰性投影，长会话同步遍历会阻塞主线程 |
| D. 调大/去掉 2000 条上限 | 简单粗暴 | ❌ 不解决语义问题（chunk 仍占据窗口），且引入无界内存/CPU 开销 |

## 实现（+13/-2 行，单文件）

`extractSessionMessages` 在 `sessionEventsOf()` 之后、截尾之前插入一次线性过滤，只保留三类消息承载事件，然后照旧截尾。原注释中的性能护栏（不触碰 `surface.nodes`）与 2000 条窗口兜底全部保留；`seedRuntimeFromSession` 存在同类窗口问题但未在本次实证中复现失败，留待后续单独处理（避免本 PR 引入未经验证的改动）。

## 验证

1. **新增回归测试** `tests/smoke/smoke-test-extract-chunk-flood.mjs`（复用仓库的源码抽取+依赖注入模式，测随包发布的真实代码）：
   - G1 真人消息被 4680 条 chunk 淹没后仍被提取（修复点）
   - G2 消息事件 >2000 条时窗口兜底仍生效且保留最新消息
   - G3 旧版 host（`.events` 数组）行为一致
   - G4 源码守卫：过滤先于截尾（防退化）
   - 结果 **pass=5 fail=0**
2. **全量 smoke 回归**：既有 50+ 测试与 main 基线结果完全一致（m53/m63/m710/m72/m79/m81/peer-probe/c4 的失败在 main 上同样存在，为既有问题，与本 PR 无关）
3. **生产日志对照**：故障会话（session-edf80773）的两次真人提问（36/33 字）在修复后管线的模拟提取中可被完整取回，与 skip 时 `asst` 长度（1424）逐字节对上