### PR TITLE
fix: 跨工作区总结采样按记忆活跃度排序，替代字母序 slice(0,8)——修复活跃工作区被空工作区挤出概览（今日工作恒显示 0 条）

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,7 @@ import { createFactStorePre } from './fact-store.js'
 import { createProcedureStorePre } from './procedure-store.js'
 import { createMemoryHubPre } from './memory-hub.js'
 import { pickConsolidationTextPre } from './intent-clean.js'
+import { rankWorkspacesByMemoryRecencyPre } from './ws-overview-rank.js'
 import { createStorageManagerPre } from './storage-manage.js'
 import { buildSourceCatalog, CorpusRegistry, canonicalize } from './m4-corpus.js'
 import * as nodeZlib from 'node:zlib'
@@ -2953,7 +2954,14 @@ class MemoryEngine {
         }
       } catch (e) {}
     }
-    const cwds = await this.discoverWorkspaces()
+    // 2026-09-08 修复(issue #24):按记忆活跃度排序后再取样——原 slice(0,8) 直接按
+    // 字母序取样,数字/临时目录开头的空工作区挤占有记忆的活跃工作区(实测排第 25 被丢弃)。
+    const cwds = await rankWorkspacesByMemoryRecencyPre(
+      await this.discoverWorkspaces(),
+      (cwd) => this.projectDirOf(cwd),
+      readdir,
+      stat,
+    )
     const records = (await Promise.all(cwds.slice(0, 8).map(async (cwd) => {
       const mem = await this.readWorkspaceMemory(cwd)
       if (!mem || (!mem.logs.length && !mem.notes)) return null

--- a/lib/ws-overview-rank.js
+++ b/lib/ws-overview-rank.js
@@ -1,0 +1,40 @@
+/**
+ * M10 工作区总览采样排序(2026-09-08,issue #24)。
+ *
+ * 背景:workspaceOverview 对 discoverWorkspaces() 的结果做 slice(0,8) 字母序取样,
+ * 而会话目录字母序靠前的位置常被临时/一次性工作区占据(ppt_build、jobs-issue-* 等,
+ * 实测字母序前 24 位全是无记忆目录),真正带记忆的活跃工作区排在 20 位开外,
+ * 永远进不了跨工作区总结 → 面板「今日工作 0 条日志」。
+ *
+ * 修复:按「最新日志文件 mtime」降序排列后再交给调用方取样。无记忆工作区(latest=0)
+ * 自然沉底;同分保持原字母序(sort 稳定)。纯函数、零运行时依赖,IO 全部注入,可回归锁定。
+ * 截尾(slice(0,8))仍由调用方决定,本函数只负责排序,恒返回全部 cwd。
+ */
+import path from 'node:path'
+
+/** 日志文件名日期识别(与 index.js readWorkspaceMemory 的 DATE_RE 同源)。 */
+const DATE_RE = /\d{4}-\d{2}-\d{2}/
+
+/**
+ * 按记忆活跃度(最新日志 mtime)降序排列工作区。
+ * @param {string[]} cwds - discoverWorkspaces 产出的工作区路径(原顺序)。
+ * @param {(cwd:string)=>string} projectDirOf - cwd → 记忆目录 映射。
+ * @param {(dir:string)=>Promise<string[]>} readdir - 目录列表(条目名数组)。
+ * @param {(p:string)=>Promise<{mtimeMs:number}>} stat - 文件状态。
+ * @returns {Promise<string[]>} 排序后的 cwd 数组(恒返回全部,截尾由调用方决定)。
+ */
+export async function rankWorkspacesByMemoryRecencyPre(cwds, projectDirOf, readdir, stat) {
+  const ranked = await Promise.all((Array.isArray(cwds) ? cwds : []).map(async (cwd) => {
+    let latest = 0
+    try {
+      const dir = projectDirOf(cwd)
+      for (const en of await readdir(dir)) {
+        if (!DATE_RE.test(String(en).replace(/\.md$/, ''))) continue
+        const m = (await stat(path.join(dir, String(en)))).mtimeMs
+        if (m > latest) latest = m
+      }
+    } catch (e) {}
+    return { cwd, latest }
+  }))
+  return ranked.sort((a, b) => b.latest - a.latest).map((x) => x.cwd)
+}

--- a/tests/smoke/smoke-test-ws-overview-rank.mjs
+++ b/tests/smoke/smoke-test-ws-overview-rank.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/** [ws-rank] 工作区总览采样排序回归(2026-09-08,issue #24)。
+ * 直接导入随包发布的 lib/ws-overview-rank.js 纯函数:
+ *   G1 活跃工作区排前:最新日志 mtime 降序
+ *   G2 无记忆工作区(latest=0)沉底
+ *   G3 恒返回全部 cwd(截尾是调用方职责,函数自身不丢工作区)
+ *   G4 同分稳定:两次运行同结果
+ *   G5 目录缺失/IO 失败不抛错(按无记忆处理)
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, utimesSync, readdirSync, statSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { rankWorkspacesByMemoryRecencyPre } from '../../lib/ws-overview-rank.js'
+
+let pass = 0, fail = 0
+const ok = (c, n) => { if (c) { pass++; console.log('  ok -', n) } else { fail++; console.log('  FAIL -', n) } }
+const tmp = mkdtempSync(path.join(os.tmpdir(), 'dam-ws-rank-'))
+
+const active = path.join(tmp, 'ws-active')
+const old = path.join(tmp, 'ws-old')
+mkdirSync(active, { recursive: true })
+mkdirSync(old, { recursive: true })
+writeFileSync(path.join(active, '2026-09-08.md'), '今日记录')
+writeFileSync(path.join(active, 'MEMORY.md'), '笔记')
+const NEW_T = new Date('2026-09-08T12:00:00')
+const OLD_T = new Date('2026-09-04T12:00:00')
+utimesSync(path.join(active, '2026-09-08.md'), NEW_T, NEW_T)
+writeFileSync(path.join(old, '2026-09-04.md'), '旧记录')
+utimesSync(path.join(old, '2026-09-04.md'), OLD_T, OLD_T)
+
+const projectDirOf = (cwd) => path.join(tmp, cwd)
+const readdir = async (dir) => { try { return readdirSync(dir) } catch (e) { return [] } }
+const stat = async (p) => statSync(p)
+
+console.log('[ws-rank] G1/G2 活跃优先,无记忆沉底')
+const cwds = ['ws-no-mem', 'ws-old', 'ws-active', 'ws-also-no-mem']
+const ranked1 = await rankWorkspacesByMemoryRecencyPre(cwds, projectDirOf, readdir, stat)
+ok(ranked1[0] === 'ws-active', '活跃工作区排第 1(实际 ' + ranked1[0] + ')')
+ok(ranked1[1] === 'ws-old', '旧工作区排第 2')
+ok(ranked1.indexOf('ws-no-mem') > 1 && ranked1.indexOf('ws-also-no-mem') > 1, '无记忆工作区沉底')
+
+console.log('[ws-rank] G3 恒返回全部 cwd')
+ok(ranked1.length === cwds.length, '长度不变(' + ranked1.length + ')')
+
+console.log('[ws-rank] G4 同分稳定')
+const ranked2 = await rankWorkspacesByMemoryRecencyPre(cwds, projectDirOf, readdir, stat)
+ok(JSON.stringify(ranked1) === JSON.stringify(ranked2), '两次运行同结果')
+
+console.log('[ws-rank] G5 目录缺失不抛错')
+const r5 = await rankWorkspacesByMemoryRecencyPre(['ws-missing'], projectDirOf, readdir, stat)
+ok(Array.isArray(r5) && r5.length === 1 && r5[0] === 'ws-missing', '缺失目录按无记忆处理')
+
+console.log('[ws-rank] 结果: pass=' + pass + ' fail=' + fail)
+process.exit(fail ? 1 : 0)


### PR DESCRIPTION
Closes #24

## 根因（详见 #24）

`workspaceOverview()` 对 `discoverWorkspaces()` 的结果做 `cwds.slice(0, 8)` 字母序取样。会话目录字母序靠前的位置被临时/一次性工作区占据（`AppData\Local\Temp\ppt_build`、`Desktop\chaxin-skills\jobs\issue-84~102` 共 15 个、大小写变体等），实测字母序**前 24 位全部无记忆目录**；带活跃记忆的工作区排第 25 位，永远进不了采样窗 → 跨工作区总结显示错误工作区 +「今日工作 0 条日志」，而实际当日日志已有 11 条且持续增长。

## 方案取舍（评估了四种修法）

| 方案 | 思路 | 影响范围 | 侵入性 | 可维护性 | 副作用 | 结论 |
|---|---|---|---|---|---|---|
| **A. 按记忆活跃度排序后再取样（本 PR）** | 统计各 cwd 记忆目录内日志最新 mtime，降序排列后 `slice(0,8)` | 仅概览展示层 | ✅ +1 纯函数模块 + 接线 3 行 | ✅ 纯函数 + smoke 回归锁定（合仓库 `_pre` 惯例） | 旧而不活跃的工作区退出概览——符合"近期活动总览"定位；`memory_recall`/检索/日志页签仍可达全部工作区 | ✅ 采用 |
| B. 去掉 slice(0,8)，全量进总结 | 27 个工作区全送 AI 总结 | AI prompt（22000 字符截断可能切坏 JSON）、fallback 面板无限增长 | 小 | 差（无界增长） | 总结被稀释 | ❌ |
| C. 只过滤"有记忆"不设上限 | 同 B 但保留过滤 | 同 B | 小 | 中 | 同样无界 | ❌ |
| D. 改 `discoverWorkspaces()` 本身按 mtime 排序 | 动共享函数 | `memory_recall` 等另外两个调用方连带受影响 | 大 | 差 | 跨功能回归风险 | ❌ |

选 A 的理由：缺陷本质是"取样代表性"问题而非发现能力问题（`discoverWorkspaces` 工作正常），在取样处按活跃度排序是最小且语义最贴切的修复；抽成纯函数（`_pre` 后缀、IO 注入、零运行时依赖）遵循仓库既有惯例（同 `intent-clean.js` 的抽取先例），可回归锁定。

## 实现

- 新增 `lib/ws-overview-rank.js`：纯函数 `rankWorkspacesByMemoryRecencyPre(cwds, projectDirOf, readdir, stat)`——按各工作区记忆目录内最新日志 mtime 降序排列，无记忆者（latest=0）沉底，同分保持原字母序（sort 稳定），**恒返回全部 cwd**（截尾仍由调用方 `slice(0,8)` 决定）
- `workspaceOverview()` 接线：discover → rank → slice(0,8)，其余逻辑（readWorkspaceMemory、AI 总结、缓存 TTL）零改动
- 有意的行为变化（副作用披露）：概览从"字母序前 8 个工作区"变为"最近活跃的 8 个有记忆工作区"；长期不活跃的工作区会退出概览（数据无损，日志/检索功能不受影响）

## 验证

1. **新增回归测试** `tests/smoke/smoke-test-ws-overview-rank.mjs`：活跃优先 / 无记忆沉底 / 恒返回全部 / 同分稳定 / 目录缺失不抛错 —— **pass=6 fail=0**
2. **全量 smoke 回归**：既有测试（含 #17/#23 的 chunk-flood 测试 pass=5 fail=0）与 main 基线一致，无新增失败
3. **生产数据对照**：故障环境下按新逻辑模拟排序，被丢弃的活跃工作区（当日 11 条记录）排到第 1 位，进入采样窗