### PR TITLE
fix(python-setup): correct BGE-M3 model repo — wizard step 4 always HTTP 401

### DIFF
--- a/lib/python-setup.js
+++ b/lib/python-setup.js
@@ -25,7 +25,7 @@ const execFileP = promisify(execFile)
 
 /** BGE-M3 int8 单文件(与 bench 夹具同源;hf-mirror 为主源,HF 官方为备源)。 */
 const MODEL_SPEC = {
-  repo: 'Xenova/bge-m3-int8',
+  repo: 'Xenova/bge-m3',
   file: 'onnx/model_int8.onnx',
   bytes: 568456694,
   sha256: '', // 见 MODEL_SHA256:远端 LFS 校验不可靠时以 size 下限+可执行性兜底;sha256 由首版发布冻结后填入


### PR DESCRIPTION
## Problem

Python engine setup wizard step 4 ("download BGE-M3 int8, ~539MB") **always fails** with `HTTP 401` on both mirrors, so the C3 (Python) tier can never be installed:

```
④ 下载 BGE-M3 int8 模型(~539MB,断点续传,失败自动换源)
[intl] HTTP 401
```

Diagnostic log (`~/.dsh/dsh-auto-memory-diagnose.log`) — 8 retries, all failed:

```
2026-09-09T06:04:03.562Z python-setup: download failed via cn:   [cn]   HTTP 401
2026-09-09T06:04:04.731Z python-setup: download failed via intl: [intl] HTTP 401
```

Note cn and intl fail **~1.1s apart** — an immediate HTTP response, not a timeout. That rules out network/proxy causes.

## Root cause

`lib/python-setup.js:28` — the repo does not exist:

```js
repo: 'Xenova/bge-m3-int8',   // no such repo on HuggingFace
```

HuggingFace returns **401 (not 404)** for unknown repos, treating them as unauthorized private repos. So the `cn -> intl` failover retries the *same broken path* and step 4 can never reach `ready`. The "auto mirror failover" is structurally useless against this class of failure.

Not a regression — both 2.2.0 and 2.2.6 carry the identical value, and npm `latest` is still 2.2.6.

## Evidence (measured locally, via proxy 127.0.0.1:7897)

| Request | Result |
| --- | --- |
| `hf-mirror.com/Xenova/bge-m3-int8/resolve/main/onnx/model_int8.onnx` | **401** |
| `huggingface.co/Xenova/bge-m3-int8/resolve/main/onnx/model_int8.onnx` | **401** |
| `huggingface.co/api/models/Xenova/bge-m3-int8` | **401** `{"error":"Invalid username or password."}` |
| `huggingface.co/api/models?author=Xenova&search=bge-m3` | only `Xenova/bge-m3` — no `bge-m3-int8` |
| `huggingface.co/Xenova/bge-m3/resolve/main/onnx/model_int8.onnx` (Range 0-0) | **206** `content-range: bytes 0-0/568456694` |

**Decisive match:** the correct file is `568,456,694` bytes, identical to `MODEL_SPEC.bytes: 568456694`. Same file, same path — only the repo name had a stray `-int8` suffix. `python/m7_embedding_v1.py:241` also documents `Xenova/bge-m3`, confirming the original intent.

## Fix

One line — repo name only. `file: 'onnx/model_int8.onnx'` is already correct and unchanged.

**Why `sha256` stays empty:** grep shows the field has no consumer — there is no verify path reading it (the `MODEL_SHA256` referenced in the comment doesn't exist either). Filling it would add unverifiable surface to a minimal fix. If/when verification is wired up, the LFS oid is:

```
a206e10e995aa2a833924bcd725ba5dd6c3425cd34bac3cf2b5677cd2a1c51d6
```

## Verification

- Before: both mirrors 401 (reproduced above)
- After: `Xenova/bge-m3` returns 206 with `content-range: bytes 0-0/568456694`, matching `MODEL_SPEC.bytes`
- Diff: 1 file, +1/-1, no behavioral surface added

## Not addressed here (separate issue)

`downloadModel()` fetches **only** `model_int8.onnx`, but `python/m7_embedding_v1.py:263` calls `AutoTokenizer.from_pretrained(modelDir)`, which needs `config.json`, `tokenizer.json`, `tokenizer_config.json`, `special_tokens_map.json`, `sentencepiece.bpe.model` in the same dir. With `HF_HUB_OFFLINE=1` (or `TRANSFORMERS_OFFLINE=1`) set, transformers cannot fetch them at runtime, so the sidecar still fails to start after a "successful" install. The JS tier (`~/.dsh/models/js-semantic/multilingual-e5-small/`) does ship the full tokenizer set — the Python tier should match. Happy to open a follow-up PR if you want it in the same change.

Also worth considering: on 401/404, failing fast with a clear message beats retrying both mirrors — 8 pointless retries showed up in my log before I found the cause.

## Environment

- Plugin 2.2.6 (`~/.dsh/profiles/desktop/node_modules/@a9i5k4/dsh-auto-memory`)
- Windows 11, Node via DSH Desktop
- Proxy 127.0.0.1:7897 (verified working — not a factor here)
- Env: `HF_HUB_OFFLINE=1`, `TRANSFORMERS_OFFLINE=1`, `NODE_USE_ENV_PROXY=1`

---

<details>
<summary>中文说明</summary>

**问题**：Python 引擎安装向导第④步恒定失败，cn/intl 双源均返回 401，C3 进阶档无法安装。

**根因**：`lib/python-setup.js:28` 仓库名 `Xenova/bge-m3-int8` 在 HuggingFace 上不存在。HF 对不存在的仓库返回 **401 而非 404**，因此"自动换源"重复请求同一个错误路径，必然双失败。2.2.0 与 2.2.6 该行一致，非回归缺陷。

**修复**：仓库名改为 `Xenova/bge-m3`（文件名 `onnx/model_int8.onnx` 不变）。实测正确文件 568,456,694 字节与 `MODEL_SPEC.bytes` 精确吻合，可确认这就是目标文件。

**为何未填 `sha256`**：该字段当前无任何消费方（无校验逻辑），填入只会扩大改动面。需要时可用 LFS oid `a206e10e...c51d6`。

**未在本 PR 处理**：tokenizer 文件缺失问题——`m7_embedding_v1.py:263` 需要完整 tokenizer 套件，但下载器只下 onnx。若环境设了 `HF_HUB_OFFLINE=1`，模型装完 sidecar 仍会启动失败。如需我一并修复请告知。
</details>
