### PR TITLE
fix: 子代理巡检改用头帧解码，修复 Node 22 下巨型会话文件令宿主进程崩溃

### DIFF
--- a/lib/subagent-gc.js
+++ b/lib/subagent-gc.js
@@ -91,6 +91,35 @@ export function decodeZstdFrames(buf) {
 }
 
 /**
+ * 头帧解码:仅解压前 maxFrames 帧(或累计超 maxBytes 即停)。
+ *
+ * 背景(实测 2026-09-11,DSH Desktop 0.5.10 / Electron 内置 Node 22.22.1):
+ * Node 22 的实验性 `node:zlib` zstd 在解压巨型会话文件(数 MB 压缩、数万帧)
+ * 时会令整个宿主进程直接崩溃(crashpad not connected,无 JS 异常可捕获);
+ * 同样的文件在 Node 24 下正常。扫描会话头(header + subagent descriptor)
+ * 只需要最前面几帧,因此扫描路径一律改用本函数,避免全量解压巨型旧会话。
+ * @param {Buffer} buf - 原始文件内容。
+ * @param {number} [maxFrames=8] - 最多解压的帧数。
+ * @param {number} [maxBytes=4*1024*1024] - 解压结果累计上限(字节),超出即停。
+ * @returns {string} 前若干帧解压文本(坏帧跳过)。
+ */
+export function decodeZstdFramesHead(buf, maxFrames = 8, maxBytes = 4 * 1024 * 1024) {
+  const parts = []
+  let frames = 0
+  let bytes = 0
+  for (const fr of scanZstdFrames(buf)) {
+    if (frames >= maxFrames || bytes >= maxBytes) break
+    try {
+      const part = zstdDecompressSync(buf.subarray(fr.start, fr.end))
+      parts.push(part)
+      frames++
+      bytes += part.length
+    } catch (e) { /* 坏帧跳过 */ }
+  }
+  return Buffer.concat(parts).toString('utf8')
+}
+
+/**
  * 从会话日志文本里取首帧 header 与 subagent descriptor。
  * @param {string} text - 解压后的 JSONL 文本。
  * @returns {{header:object|null,descriptor:{label?:string,mode?:string}|null,eventCount:number}}
@@ -180,7 +209,7 @@ export async function scanPluginSubagentSessions(opts = {}) {
       }
       if (!st) { bump('no-file'); continue }
       let text = ''
-      try { text = decodeZstdFrames(await readFile(file)) } catch (e) { bump('decode-error'); continue }
+      try { text = decodeZstdFramesHead(await readFile(file)) } catch (e) { bump('decode-error'); continue }
       const head = parseSessionHead(text)
       if (!head.header) { bump('no-header'); continue }
       if (head.header.origin === 'subagent') out.subagents++


### PR DESCRIPTION
## 问题

在 DSH Desktop 0.5.10（Electron 内置 **Node 22.22.1**）下，本插件的每日兜底巡检 `scanPluginSubagentSessions` 会对 `~/.dsh/sessions` 下每个会话**全量解压**（`decodeZstdFrames`）。Node 22 的实验性 `node:zlib` zstd 在解压巨型会话文件（实测 4.3MB / 9.7MB / 15.4MB / 23.5MB 压缩、数万帧）时**直接令整个宿主进程崩溃**（crashpad 报 `not connected`，无 JS 异常可捕获），导致 dsh web 启动后 60–155 秒必崩 —— 表现为"桌面端装了 auto-memory 就起不来"。同样的文件在 Node 24 下解压正常。

## 修复

- 新增 `decodeZstdFramesHead(buf, maxFrames=8, maxBytes=4MB)`：只解前若干帧即停。会话 header 与 subagent descriptor 本就位于首帧附近，扫描判定（`parseSessionHead` 找到两者即 break）不需要全文；
- `scanPluginSubagentSessions` 改用头帧解码。

`decodeZstdFrames` 原样保留，其它调用方（如确实需要全文的 consolidated 路径）行为不变。

## 遗留建议（本 PR 未含，供参考）

`lib/index.js` 的 `waterWindowForSession` 里 `decodeZstdFrames(raw)` 同样是全量解压路径（切会话推导模型/窗口时触发），建议同样切到头帧解码（如 `decodeZstdFramesHead(raw, 32, 8 * 1024 * 1024)`，模型信息事件在会话开头）；需要的话我可以补一个 commit。

## 验证

- 257 个会话文件（含三个此前必崩的巨型会话）在 Node 22.22.1 下全量扫描通过；
- 带插件的 dsh web 运行时在 Electron 内置 Node 下稳定运行超过 4 分钟（此前必崩）；
- 头帧解码下 `parseSessionHead` 对全部 257 个会话仍能正确取到 header/descriptor。